### PR TITLE
Use mktemp to create temporary directory

### DIFF
--- a/pdf2odt
+++ b/pdf2odt
@@ -172,14 +172,23 @@ if [ -e "${out}" ] &&
   exit 1
 fi
 
-# Set up temporary staging directory
-TMPDIR="/tmp/pdf2odt.$$"
-[ \! -e "${TMPDIR}" ] || {
-  echo "Staging directory ${TMPDIR} already exists" >&2
-  exit 1
-}
+# Set up temporary staging directory. In an ideal world, we'd use "mktemp -d",
+# but this features doesn't necessarily exist on all supported platforms. If
+# necessary, we fall back on finding a unique filename in the system-wide
+# temporary directory and then creating a staging directory for our own use. An
+# attempt will be made to restrict permissions. Also, we honor the value
+# of "${TMPDIR}" if it is set. For more security-sensitive applications,
+# setting "${TMPDIR}" to a suitable unique per-invocation value before calling
+# "pdf2odt" might be a good idea.
+if ! TMPDIR="$(mktemp -d)" 2>/dev/null; then
+  TMPDIR=${TMPDIR:-/tmp/pdf2odt.$$}
+  install -dm0700 "$TMPDIR"
+fi
+# Force all third parties to write to our staging directory.
+export TMPDIR
+
+# Clean up our staging directory, if we exit unexpectedly
 trap 'rm -rf "${TMPDIR}"' EXIT INT TERM QUIT HUP
-mkdir -p "${TMPDIR}"
 
 # Adjust DPI so that the image fits on a letter- or a4-sized page.
 function scale() {


### PR DESCRIPTION
Instead of the homegrown solution to create a temporary directory, just use `mktemp -d` which does so securely.
